### PR TITLE
Keeping black color font on light-green background

### DIFF
--- a/components/Button/index.js
+++ b/components/Button/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 export const Button = React.forwardRef((props, ref) => {
   const stdClass =
-    'text-black-300 border-transparent dark:text-white-100 font-medium rounded-lg bg-primary-300 px-4 py-3 text-sm transition duration-150 ease-in-out'
+    'text-black-300 border-transparent font-medium rounded-lg bg-primary-300 px-4 py-3 text-sm transition duration-150 ease-in-out'
   const primaryButton = props?.disabled
     ? `${stdClass} ${props?.customClass}`
     : `${stdClass} cursor-pointer hover:bg-primary-200 dark:hover:bg-primary-400 ${


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3437672/180587146-b10ede18-989a-49ef-bd82-0b9afaa37474.png)
Melhorando contraste do botão com fundo verde claro tirando a fonte branca e mantendo a fonte preta.