### PR TITLE
fix copy share course on twitter

### DIFF
--- a/components/Card/ShareLink/index.js
+++ b/components/Card/ShareLink/index.js
@@ -64,7 +64,7 @@ export default function ShareLinkCard() {
               <a
                 className="twitter-share-button text-black-100 dark:text-white-100"
                 id={`share-twitter`}
-                href={`https://twitter.com/intent/tweet?text=Novo curso 100%25 gratuito da Web3Dev sobre Smart Contracts, ainda vou ganhar um NFT no final, eu já me inscrevi, e você? ${shortenedUrl}`}
+                href={`https://twitter.com/intent/tweet?text=Novo curso 100%25 gratuito da Web3Dev, ainda vou ganhar um NFT no final, eu já me inscrevi, e você? ${shortenedUrl}`}
                 target="_blank"
                 data-size="large"
               >


### PR DESCRIPTION
The current twitter share modal copy refear a specific bootcamp, i fix it whit a generic copy 

Image of current twitter share copy :
https://i.imgur.com/KgNUS3h.png