### PR TITLE
Fix: Open or close the amount filter dropdown based on reward selection

### DIFF
--- a/components/Filter/utils.js
+++ b/components/Filter/utils.js
@@ -145,6 +145,10 @@ export const useFilterState = (issues) => {
         }
         if (filterName === 'Reward') {
           updatedFilters['Amount'] = null
+          setIsOpen((currentOpenState) => ({
+            ...currentOpenState,
+            Amount: updatedFilters['Reward'] !== null,
+          }))
         }
         updateUrlWithFilters(updatedFilters)
         return updatedFilters


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

The type of this pull request is:

- [X] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

Open or close the amount filter dropdown based on reward selection

### Fixed issues

<!--
- #User could not log in
-->


## Details

### Before: What was the problem?

![image](https://github.com/user-attachments/assets/319a8da4-7169-4cba-81fc-7d248c5c0a93)

### After: How does it behave after the fixing?

![image](https://github.com/user-attachments/assets/3124ef90-b941-4016-a0c2-715a47eaf5df)

### Test: How did you test the issue?

<!-- A TEST CASE CATCHING THE ISSUE MENTIONED -->


## Others

### Merging options

- [X] Please squash the commits into a single one when merging.

### Other information

Closes #227 